### PR TITLE
Add codesigning issue notice for iOS SDK v19.5.6 and v19.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ![Intercom](https://user-images.githubusercontent.com/6392766/92717163-af7b0200-f357-11ea-9dc3-6f86d0c21d96.png)
 
+
+## ⚠️ May 1st Codesigning issue ⚠️ 
+If you are running iOS SDK [v19.5.6](https://github.com/intercom/intercom-ios/releases/tag/19.5.6) or [v19.5.7](https://github.com/intercom/intercom-ios/releases/tag/19.5.7) and are experiecing a codesigning issue, [please follow these steps](https://github.com/intercom/intercom-ios/wiki/Codesigning-Issue) to resolve it.
+
+
+
 ## Installation
 
 Intercom for iOS supports iOS 15+. 


### PR DESCRIPTION
Added a note about codesigning issues for specific SDK versions.